### PR TITLE
Switch to def/indef encoding; add a test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2524,7 +2524,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "plutus-parser"
 version = "0.1.0"
-source = "git+https://github.com/SundaeSwap-finance/plutus-parser.git?rev=91a7f44#91a7f44972f6ac9f0e4acdc4e5cb11a2bda88b4b"
+source = "git+https://github.com/SundaeSwap-finance/plutus-parser?rev=8a77d17#8a77d17e60031b4c5aa8fefc0ec621db23f2893f"
 dependencies = [
  "indexmap 2.9.0",
  "pallas-primitives",
@@ -2535,7 +2535,7 @@ dependencies = [
 [[package]]
 name = "plutus-parser-derive"
 version = "0.1.0"
-source = "git+https://github.com/SundaeSwap-finance/plutus-parser.git?rev=91a7f44#91a7f44972f6ac9f0e4acdc4e5cb11a2bda88b4b"
+source = "git+https://github.com/SundaeSwap-finance/plutus-parser?rev=8a77d17#8a77d17e60031b4c5aa8fefc0ec621db23f2893f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/workers/dollar-cost-average/Cargo.toml
+++ b/workers/dollar-cost-average/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "35db068" }
 hex = "0.4"
-plutus-parser = { git = "https://github.com/SundaeSwap-finance/plutus-parser.git", rev = "91a7f44", features = ["derive"] }
+plutus-parser = { git = "https://github.com/SundaeSwap-finance/plutus-parser", rev = "8a77d17", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 url = "2.5"

--- a/workers/dollar-cost-average/src/types.rs
+++ b/workers/dollar-cost-average/src/types.rs
@@ -92,3 +92,46 @@ pub fn serialize<T: AsPlutus>(value: T) -> Vec<u8> {
     minicbor::encode(value.to_plutus(), &mut bytes).expect("infallible");
     bytes
 }
+
+#[test]
+pub fn test_strategy_serialization() {
+    let (offer_policy_id, offer_asset_name) = (vec![], vec![]);
+    let (receive_policy_id, receive_asset_name) = (
+        hex::decode("99b071ce8580d6a3a11b4902145adb8bfd0d2a03935af8cf66403e15").unwrap(),
+        hex::decode("534245525259").unwrap()
+    );
+
+    let validity_range = Interval {
+        lower_bound: IntervalBound {
+            bound_type: IntervalBoundType::Finite(1752270497000u64),
+            is_inclusive: true,
+        },
+        upper_bound: IntervalBound {
+            bound_type: IntervalBoundType::Finite(1752272897000u64),
+            is_inclusive: true,
+        },
+    };
+
+    let swap = Order::Swap {
+        offer: (offer_policy_id, offer_asset_name, 10000000),
+        min_received: (
+            receive_policy_id,
+            receive_asset_name,
+            1,
+        ),
+    };
+
+    let execution = StrategyExecution {
+        tx_ref: OutputReference {
+            transaction_id: TransactionId(hex::decode("da432ef16b7aa9b3972bdd42f86e6605c14444e75678f4e6fd75baa01168086f").unwrap()),
+            output_index: 0,
+        },
+        validity_range,
+        details: swap,
+        extensions: vec![],
+    };
+
+    let bytes = serialize(execution.clone());
+    let expected_bytes = hex::decode("d8799fd8799fd8799f5820da432ef16b7aa9b3972bdd42f86e6605c14444e75678f4e6fd75baa01168086fff00ffd8799fd8799fd87a9f1b00000197fb75e4e8ffd87a80ffd8799fd87a9f1b00000197fb9a83e8ffd87a80ffffd87a9f9f40401a00989680ff9f581c99b071ce8580d6a3a11b4902145adb8bfd0d2a03935af8cf66403e154653424552525901ffff40ff").unwrap();
+    assert_eq!(bytes, expected_bytes);
+}


### PR DESCRIPTION
The sc's need to call cbor.serialise to check the signature, which doesn't respect the original encoding; so we need to match their conventions to make sure the signature stays valid