### PR TITLE
feat: add helper methods to improve developer experience

### DIFF
--- a/sundae-strategies/src/types.rs
+++ b/sundae-strategies/src/types.rs
@@ -55,7 +55,14 @@ impl From<(Vec<u8>, Vec<u8>)> for AssetId {
     }
 }
 
+impl PartialEq<InlineAssetId> for AssetId {
+    fn eq(&self, other: &InlineAssetId) -> bool {
+        self.policy_id == other.0 && self.asset_name == other.1
+    }
+}
+
 pub type InlineAssetId = (Vec<u8>, Vec<u8>);
+
 #[derive(AsPlutus, Serialize, Deserialize, Debug, Clone)]
 pub struct PoolDatum {
     pub identifier: Vec<u8>,


### PR DESCRIPTION
This PR introduces 4 new helper methods to improve the developer experience for writing strategy event handlers:

`order.submit_execution(network: &Network, validity_range: Interval, details: Order)`: Wrapper for `submit_execution` that doesn't require manually providing an `OutputReference`. 

`pool_state.pool_tokens_match_config(a: &AssetId, b: &AssetId)`: Returns `true` if the pool datum specifies both assets, allowing filtering of unrelated pools.

`pool_state.price(sell_token_decimals: i32, buy_token_decimals: i32)`: Returns the pool price adjusted for token decimals. This enables using execution prices as displayed on the DEX.

`pool_state.get_validity_range(network: &Network, seconds: u64)`: Builds a validity range relative to the pool state slot, eliminating the need for manual construction by strategy authors. 

These helpers reduce clutter in strategy logic by handling common setup tasks, letting developers focus directly on execution flow. 